### PR TITLE
[strong] Disallow fall through in case clauses

### DIFF
--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -500,29 +500,27 @@ export class DestructuringTransformer extends TempVarTransformer {
       case OBJECT_LITERAL_EXPRESSION:
       case PAREN_EXPRESSION:
         initializer = tree.initializer;
-
-      // Paren necessary for single value case.
-      default:
-        // [1] Try first using a temporary (used later as the base rvalue).
-        desugaring = new VariableDeclarationDesugaring(tempRValueIdent);
-        desugaring.assign(desugaring.rvalue, tree.initializer);
-        let initializerFound = this.desugarPattern_(desugaring, tree.lvalue);
-
-        // [2] Was the temporary necessary? Then return.
-        if (initializerFound || desugaring.declarations.length > 2) {
-          return desugaring.declarations;
-        }
-
-        if (!initializer) {
-          initializer = createParenExpression(tree.initializer);
-        }
-
-        // [3] Redo everything without the temporary.
-        desugaring = new VariableDeclarationDesugaring(initializer);
-        this.desugarPattern_(desugaring, tree.lvalue);
-
-        return desugaring.declarations;
     }
+
+    // [1] Try first using a temporary (used later as the base rvalue).
+    desugaring = new VariableDeclarationDesugaring(tempRValueIdent);
+    desugaring.assign(desugaring.rvalue, tree.initializer);
+    let initializerFound = this.desugarPattern_(desugaring, tree.lvalue);
+
+    // [2] Was the temporary necessary? Then return.
+    if (initializerFound || desugaring.declarations.length > 2) {
+      return desugaring.declarations;
+    }
+
+    if (!initializer) {
+      initializer = createParenExpression(tree.initializer);
+    }
+
+    // [3] Redo everything without the temporary.
+    desugaring = new VariableDeclarationDesugaring(initializer);
+    this.desugarPattern_(desugaring, tree.lvalue);
+
+    return desugaring.declarations;
   }
 
   /**

--- a/src/codegeneration/TemplateLiteralTransformer.js
+++ b/src/codegeneration/TemplateLiteralTransformer.js
@@ -41,6 +41,7 @@ import {
   createCallExpression,
   createIdentifierExpression,
   createOperatorToken,
+  createParenExpression,
   createStringLiteral
 } from './ParseTreeFactory.js';
 import {parseExpression} from './PlaceholderParser.js';
@@ -231,10 +232,11 @@ export class TemplateLiteralTransformer extends TempVarTransformer {
           case SLASH:
             return transformedTree;
         }
-        // Fall through.
+        return createParenExpression(transformedTree);
+
       case COMMA_EXPRESSION:
       case CONDITIONAL_EXPRESSION:
-        return new ParenExpression(null, transformedTree);
+        return createParenExpression(transformedTree);
     }
 
     return transformedTree;

--- a/src/syntax/ParseTreeValidator.js
+++ b/src/syntax/ParseTreeValidator.js
@@ -783,6 +783,7 @@ export class ParseTreeValidator extends ParseTreeVisitor {
         case PROPERTY_METHOD_ASSIGNMENT:
           this.check_(!propertyNameAndValue.isStatic, propertyNameAndValue,
                       'static is not allowed in object literal expression');
+          break;
         case PROPERTY_NAME_ASSIGNMENT:
         case PROPERTY_NAME_SHORTHAND:
           break;

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -444,9 +444,11 @@ function skipTemplateCharacter() {
         let code = input.charCodeAt(index + 1);
         if (code === 123)  // {
           return;
-        // Fall through.
+        next();
+        break;
       default:
         next();
+        break;
     }
   }
 }

--- a/src/syntax/trees/ParseTree.js
+++ b/src/syntax/trees/ParseTree.js
@@ -397,7 +397,6 @@ export class ParseTree {
   }
 
   isUseStrongDirective() {
-    // TODO(arv): Rename
     return this.isDirective_('strong');
   }
 

--- a/test/feature/StrongMode/Disabled_SwitchFallThrough.js
+++ b/test/feature/StrongMode/Disabled_SwitchFallThrough.js
@@ -1,0 +1,9 @@
+// Not enabled.
+'use strong';
+
+switch (42) {
+  case 1:
+    2;
+  case 3:
+    4;
+}

--- a/test/feature/StrongMode/Error_SwitchFallThrough.js
+++ b/test/feature/StrongMode/Error_SwitchFallThrough.js
@@ -1,0 +1,115 @@
+// Options: --strong-mode
+// Error: :17:3: Fall through is not allowed in strong mode
+// Error: :24:3: Fall through is not allowed in strong mode
+// Error: :35:3: Fall through is not allowed in strong mode
+// Error: :46:3: Fall through is not allowed in strong mode
+// Error: :55:3: Fall through is not allowed in strong mode
+// Error: :67:5: Fall through is not allowed in strong mode
+// Error: :84:5: Fall through is not allowed in strong mode
+// Error: :95:5: Fall through is not allowed in strong mode
+// Error: :112:5: Fall through is not allowed in strong mode
+
+'use strong';
+
+switch (42) {
+  case 1:
+    2;
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1: {
+  }
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1:
+    if (true) {
+      break;
+    } else {
+
+    }
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1:
+    if (true) {
+
+    } else {
+      break;
+    }
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1:
+    switch (55) {
+
+    }
+  case 3:
+    4;
+}
+
+(function() {
+  switch (42) {
+    case 1:
+      switch (55) {
+        case 2:
+          return;
+        // no default.
+      }
+    case 3:
+      4;
+  }
+});
+
+(function() {
+  switch (42) {
+    case 1:
+      switch (55) {
+        case 2:
+          return;
+        case 3:
+          break;  // does not break out of outer switch.
+        default:
+          return;
+
+      }
+    case 4:
+      5;
+  }
+});
+
+(function() {
+  switch (42) {
+    case 1:
+      return;
+    case 2:
+      switch (55) {}
+    case 3:
+      return;
+  }
+});
+
+(function() {
+  switch (42) {
+    case 1:
+      return;
+    case 2:
+      switch (55) {
+        case 3:
+          return;
+        default:
+          return;
+        case 4:
+      }
+    case 5:
+      return;
+  }
+});

--- a/test/feature/StrongMode/SwitchFallThrough.js
+++ b/test/feature/StrongMode/SwitchFallThrough.js
@@ -1,0 +1,87 @@
+// Options: --strong-mode
+
+'use strong';
+
+switch (42) {
+  case 1:
+    2;
+}
+
+switch (42) {
+  case 1:
+    2;
+    break;
+  case 3:
+    4;
+}
+
+(function() {
+  switch (42) {
+    case 1:
+      2;
+      return;
+    case 3:
+      4;
+  }
+});  // No need to invoke.
+
+while (false) {
+  switch (42) {
+    case 1:
+      2;
+      continue;
+    case 3:
+      4;
+  }
+}
+
+switch (42) {
+  case 1:
+    2;
+    throw 42;
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1:
+  case 2:
+    3;
+    break;
+  case 4:
+    5;
+}
+
+switch (42) {
+  case 1: {
+    2;
+    break;
+  }
+  case 3:
+    4;
+}
+
+switch (42) {
+  case 1:
+    if (false) {
+      break;
+    } else {
+      break;
+    }
+  case 3:
+    4;
+}
+
+(function() {
+  switch (42) {
+    case 1:
+      switch (37) {
+        case 2:
+          return;
+        default:
+          throw 55;
+      }
+    case 3:
+      4;
+  }
+});  // No need to invoke.


### PR DESCRIPTION
This is done by checking the statements of the switch AST after it
has been parsed. This way the last clause does not need an exit
statement which is common in practice.