### PR TITLE
[strong] Do not allow Declarations in case clauses

### DIFF
--- a/src/codegeneration/CommonJsModuleTransformer.js
+++ b/src/codegeneration/CommonJsModuleTransformer.js
@@ -106,10 +106,11 @@ export class CommonJsModuleTransformer extends ModuleTransformer {
       let descriptor;
 
       switch (exp.type) {
-        case GET_ACCESSOR:
+        case GET_ACCESSOR: {
           let getterFunction = createFunctionExpression(createEmptyParameterList(), exp.body);
           descriptor = parseExpression `{get: ${getterFunction}}`;
           break;
+        }
 
         case PROPERTY_NAME_ASSIGNMENT:
           descriptor = parseExpression `{value: ${exp.value}}`;

--- a/src/codegeneration/ComprehensionTransformer.js
+++ b/src/codegeneration/ComprehensionTransformer.js
@@ -71,17 +71,19 @@ export class ComprehensionTransformer extends TempVarTransformer {
     for (let i = tree.comprehensionList.length - 1; i >= 0; i--) {
       let item = tree.comprehensionList[i];
       switch (item.type) {
-        case COMPREHENSION_IF:
+        case COMPREHENSION_IF: {
           let expression = this.transformAny(item.expression);
           statement = createIfStatement(expression, statement);
           break;
-        case COMPREHENSION_FOR:
+        }
+        case COMPREHENSION_FOR: {
           let left = this.transformAny(item.left);
           let iterator = this.transformAny(item.iterator);
           let initializer = createVariableDeclarationList(bindingKind,
                                                           left, null);
           statement = createForOfStatement(initializer, iterator, statement);
           break;
+        }
         default:
           throw new Error('Unreachable.');
       }

--- a/src/codegeneration/DestructuringTransformer.js
+++ b/src/codegeneration/DestructuringTransformer.js
@@ -532,7 +532,7 @@ export class DestructuringTransformer extends TempVarTransformer {
     let initializerFound = false;
     let pattern;
     switch (tree.type) {
-      case ARRAY_PATTERN:
+      case ARRAY_PATTERN: {
         pattern = tree;
         this.pushTempScope();
         let iterId = createIdentifierExpression(this.addTempVar());
@@ -562,8 +562,9 @@ export class DestructuringTransformer extends TempVarTransformer {
         }
         this.popTempScope();
         break;
+      }
 
-      case OBJECT_PATTERN:
+      case OBJECT_PATTERN: {
         pattern = tree;
 
         let elementHelper = (lvalue, initializer) => {
@@ -585,7 +586,7 @@ export class DestructuringTransformer extends TempVarTransformer {
               elementHelper(field.binding, field.initializer);
               break;
 
-            case OBJECT_PATTERN_FIELD:
+            case OBJECT_PATTERN_FIELD: {
               if (field.element.initializer)
                 initializerFound = true;
               let name = field.name;
@@ -593,12 +594,14 @@ export class DestructuringTransformer extends TempVarTransformer {
                   name, field.element.initializer);
               desugaring.assign(field.element, lookup);
               break;
+            }
 
             default:
               throw Error('unreachable');
           }
         });
         break;
+      }
 
       case PAREN_EXPRESSION:
         return this.desugarPattern_(desugaring, tree.expression);

--- a/src/codegeneration/ExponentiationTransformer.js
+++ b/src/codegeneration/ExponentiationTransformer.js
@@ -25,15 +25,17 @@ import {parseExpression} from './PlaceholderParser.js';
 export class ExponentiationTransformer extends TempVarTransformer {
   transformBinaryExpression(tree) {
     switch (tree.operator.type) {
-      case STAR_STAR:
+      case STAR_STAR: {
         let left = this.transformAny(tree.left);
         let right = this.transformAny(tree.right);
         return parseExpression `Math.pow(${left}, ${right})`;
+      }
 
-      case STAR_STAR_EQUAL:
+      case STAR_STAR_EQUAL: {
         let exploded =
             new ExplodeExpressionTransformer(this).transformAny(tree);
         return this.transformAny(exploded);
+      }
     }
 
     return super.transformBinaryExpression(tree);

--- a/src/codegeneration/ModuleTransformer.js
+++ b/src/codegeneration/ModuleTransformer.js
@@ -222,13 +222,14 @@ export class ModuleTransformer extends TempVarTransformer {
   transformExportDefault(tree) {
     switch (tree.expression.type) {
       case CLASS_DECLARATION:
-      case FUNCTION_DECLARATION:
+      case FUNCTION_DECLARATION: {
         let nameBinding = tree.expression.name;
         let name = createIdentifierExpression(nameBinding.identifierToken);
         return new AnonBlock(null, [
           tree.expression,
           parseStatement `var $__default = ${name}`
         ]);
+      }
     }
     return parseStatement `var $__default = ${tree.expression}`;
   }

--- a/src/staticsemantics/PropName.js
+++ b/src/staticsemantics/PropName.js
@@ -32,11 +32,12 @@ import {IDENTIFIER} from '../syntax/TokenType.js';
  */
 export function propName(tree) {
   switch (tree.type) {
-    case LITERAL_PROPERTY_NAME:
+    case LITERAL_PROPERTY_NAME: {
       let token = tree.literalToken;
       if (token.isKeyword() || token.type === IDENTIFIER)
         return token.toString();
       return String(tree.literalToken.processedValue);
+    }
     case COMPUTED_PROPERTY_NAME:
       return '';
     case PROPERTY_NAME_SHORTHAND:

--- a/src/syntax/LiteralToken.js
+++ b/src/syntax/LiteralToken.js
@@ -97,7 +97,7 @@ class StringParser {
       case 'x':
         // 2 hex digits
         return String.fromCharCode(parseInt(this.next().value + this.next().value, 16));
-      case 'u':
+      case 'u': {
         let nextValue = this.next().value;
         if (nextValue === '{') {
           let hexDigits = '';
@@ -115,6 +115,7 @@ class StringParser {
         // 4 hex digits
         return String.fromCharCode(parseInt(nextValue + this.next().value +
                                             this.next().value + this.next().value, 16));
+      }
 
       default:
         if (Number(ch) < 8)
@@ -150,7 +151,7 @@ export class LiteralToken extends Token {
       case NULL:
         return null;
 
-      case NUMBER:
+      case NUMBER: {
         let value = this.value;
         if (value.charCodeAt(0) === 48) {  // 0
           switch (value.charCodeAt(1)) {
@@ -163,10 +164,12 @@ export class LiteralToken extends Token {
           }
         }
         return Number(this.value);
+      }
 
-      case STRING:
+      case STRING: {
         let parser = new StringParser(this.value);
         return parser.parse();
+      }
 
       default:
         throw new Error('Not implemented');

--- a/src/syntax/Scanner.js
+++ b/src/syntax/Scanner.js
@@ -440,15 +440,15 @@ function skipTemplateCharacter() {
       case 92:  // \
         skipStringLiteralEscapeSequence();
         break;
-      case 36:  // $
+      case 36: {  // $
         let code = input.charCodeAt(index + 1);
         if (code === 123)  // {
           return;
         next();
         break;
+      }
       default:
         next();
-        break;
     }
   }
 }

--- a/test/feature/StrongMode/DeclarationsInCase.js
+++ b/test/feature/StrongMode/DeclarationsInCase.js
@@ -1,0 +1,22 @@
+// Options: --strong-mode
+
+'use strong';
+
+switch (1) {
+  case 2: {
+    let x;
+    break;
+  }
+  case 3: {
+    const y = 4;
+    break;
+  }
+  case 5: {
+    function f() {}
+    break;
+  }
+  default: {
+    class C {}
+    break;
+  }
+}

--- a/test/feature/StrongMode/Disabled_DeclarationsInCase.js
+++ b/test/feature/StrongMode/Disabled_DeclarationsInCase.js
@@ -1,0 +1,18 @@
+// Not enabled.
+
+'use strong';
+
+switch (1) {
+  case 2:
+    let x;
+    break;
+  case 3:
+    const y = 4;
+    break;
+  case 5:
+    function f() {}
+    break;
+  default:
+    class C {}
+    break;
+}

--- a/test/feature/StrongMode/Error_DeclarationsInCase.js
+++ b/test/feature/StrongMode/Error_DeclarationsInCase.js
@@ -1,0 +1,22 @@
+// Options: --strong-mode
+// Error: :11:5: Unexpected reserved word let
+// Error: :14:5: Unexpected reserved word const
+// Error: :17:5: Unexpected reserved word function
+// Error: :20:5: Unexpected reserved word class
+
+'use strong';
+
+switch (1) {
+  case 2:
+    let x;
+    break;
+  case 3:
+    const y = 4;
+    break;
+  case 5:
+    function f() {}
+    break;
+  default:
+    class C {}
+    break;
+}


### PR DESCRIPTION
ES6 allows declarations in case/default clauses. The scope of these are
the entire switch block which is confusing and error prone. Strong mode
disallows these and if you want a declaration in you case/default you
can always add a block.