### PR TITLE
[strong] Switch to iojs 1.5 and use new features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - iojs-v1.5

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,16 @@ bin/traceur-bare.js: src/traceur-import.js build/compiled-by-previous-traceur.js
 concat: bin/traceur-runtime.js bin/traceur-bare.js
 	cat $^ > bin/traceur.js
 
+STRONG_OPTIONS = --strong-mode \
+	--block-binding=parse \
+	--for-of=parse \
+	--generators=parse \
+	--numeric-literals=parse \
+	--template-literals
+
 bin/traceur.js: build/compiled-by-previous-traceur.js $(SRC_NODE)
 	@cp $< $@; touch -t 197001010000.00 bin/traceur.js
-	./traceur --strong-mode --out bin/traceur.js \
+	./traceur $(STRONG_OPTIONS) --out bin/traceur.js \
 	  --referrer='traceur@$(PACKAGE_VERSION)/bin/' \
 	  $(RUNTIME_SCRIPTS) $(TFLAGS) $(SRC)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Traceur Authors",
   "license": "Apache License 2.0",
   "engines": {
-    "node": ">=0.10"
+    "iojs": ">=1.5"
   },
   "main": "./src/node/api.js",
   "bin": {

--- a/src/codegeneration/PlaceholderParser.js
+++ b/src/codegeneration/PlaceholderParser.js
@@ -22,7 +22,6 @@ import {
 } from '../syntax/trees/ParseTreeType.js';
 import {IdentifierToken} from '../syntax/IdentifierToken.js';
 import {LiteralToken} from '../syntax/LiteralToken.js';
-import {Map} from '../runtime/polyfills/Map.js';
 import {CollectingErrorReporter} from '../util/CollectingErrorReporter.js';
 import {Options} from '../Options.js';
 import {ParseTree} from '../syntax/trees/ParseTree.js';

--- a/src/codegeneration/generator/CPSTransformer.js
+++ b/src/codegeneration/generator/CPSTransformer.js
@@ -647,7 +647,7 @@ export class CPSTransformer extends TempVarTransformer {
       }
     }
     // Fix up dangling state transitions.
-    for (i = 0; i < newStates.length; i++) {
+    for (let i = 0; i < newStates.length; i++) {
       newStates[i] = emptyStates.reduce((state, {id, fallThroughState}) => {
         return state.replaceState(id, fallThroughState);
       }, newStates[i]);

--- a/src/semantics/ScopeVisitor.js
+++ b/src/semantics/ScopeVisitor.js
@@ -14,7 +14,6 @@
 
 'use strong';
 
-import {Map} from '../runtime/polyfills/Map.js';
 import {ParseTreeVisitor} from '../syntax/ParseTreeVisitor.js';
 import {VAR} from '../syntax/TokenType.js';
 import {Scope} from './Scope.js';


### PR DESCRIPTION
io.js v1.5 has a newer version of V8. The following features are now
kept in bin/traceur.js:

  - block binding (let, const, functions in block)
  - template literals
  - numeric literals
  - generators
  - for of

This also changes the required version in package.json and .travis.yml.
Make sure you `nvm install iojs`.